### PR TITLE
Updating the main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ![CCBYSA](https://img.shields.io/badge/License-CC%20BY%20SA%204-blue)
 
 <img src="/images/logo_2020.svg" alt="logo" width="400px"/>
-OpenEEW is an open network of affordable seismic stations distributed around the world that send data to a detection system for earthquake early-warnings (EEWs). 
+OpenEEW is an open network of affordable seismic stations distributed around the world that send data to a detection system for earthquake early-warnings (EEWs).
 
-Traditional government-run EEWs have cost 10s millions of USD, but instead we rely on modern off-the-shelf IoT and Cloud technologies. Since 2017, Grillo has demonstrated that a cheaper IoT-based EEW can perform as well as an expensive traditional solution.
+Traditional government-run EEWs have cost 10s millions of USD, but instead OpenEEW relies on modern and affordable off-the-shelf IoT and Cloud technologies. Since 2017 [Grillo has demonstrated](https://grillo.io/comparison-of-mexicos-earthquake-early-warning-systems/) that a cheaper IoT-based EEW can perform as well as an expensive traditional solution.
 
 ## Learn More
-Please refer here for more information about the various Earthquake Early-Warnings, their evolution and the uniqueness of our open source solution.
+Please refer to the Wiki for more information about Earthquake Early-Warnings, the function, various implementations, and the uniqueness of OpenEEW's open source solution.
 
 ## Get Started
 To participate you need an OpenEEW seismic sensor. You can make your own PCB following these instructions, or you can buy one at directly from PCBWay.
@@ -30,63 +30,6 @@ Our community is active on [Slack](https://join.slack.com/t/openeew/shared_invit
 ## History
 OpenEEW was initiated by [Grillo](https://grillo.io) in 2019 as a means to share its growing [sensor data](https://registry.opendata.aws/grillo-openeew/) via the AWS Open Data program. In 2020, IBM and Linux Foundation joined to support the open source project and help expand it to include hardware schematics and firmware, as well as code for the detection system, dashboard and alerts.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-## What is an Earthquake Early-Warning (EEW) ?
-An earthquake early-warning (EEW) system is a set of capacities to detect and characterize a significant earthquake, estimating the distribution of shaking and distribute the information to communities and organizations, enabling individuals to prepare and act appropriately and in sufficient time to reduce the possibility of loss and protect life. 
-
-The alerts are sent in real-time to people before the shaking or the strong part arrives. However, [only some governments have attempted to build EEWs](http://www.unesco.org/new/en/natural-sciences/special-themes/disaster-risk-reduction/geohazard-risk-reduction/early-warning-systems/ip-eews/) due to the incredibly high-cost of traditional seismometers, dedicated telecommunications, and bespoke software.
-
-[Grillo](https://grillo.io) has already demonstrated that an IoT-based approach to EEW systems is not only within the reach of many global citizens, but [performs as well if not better than some government-run systems](https://openeew.com/blog/eew-benchmark). 
-
-***OpenEEW*** is a [Call for Code® with The Linux Foundation](https://www.linuxfoundation.org/projects/code-and-response/) project that features a set of core Grillo EEW components; hardware, software and know-how, that will place effective EEWs to be within the reach of many underserved communities around the world.
-
-All OpenEEW projects require the following components:
-
-- **A network of OpenEEW sensors**. You can [build your own](https://openeew.com/docs/build-sensor), [buy here](https://grillo.io/product/openeew-node/), or use someone else's network. 
-<img src="/images/openeew-sensor.svg" alt="sensor" width="200"/>
-
--  **A detection system running on a server**. You can find instructions for deploying your own [here](https://openeew.com/docs/deploy-detection-docker).
-<img src="/images/openeew-detection.svg" alt="detection" width="200"/>
-
-- **A method for sending alerts**. For example, to a Twitter account, via [a mobile app](https://openeew.com/docs/build-app), or an IoT device. 
-<img src="/images/openeew-alarm.svg" alt="alarm" width="200"/>
-
-## Getting Started
-Start by reading this [OpenEEW project website section](http://openeew.com/docs/read-first) which leads to tutorials, guidance and more.
-
-You are also welcome to join our [Slack](https://join.slack.com/t/openeew/shared_invite/zt-cibhc0za-XKReMPobi2DsrPusORJZVQ) for getting to know the community and discussing issues in real-time, including the creation of a network for your region.
-
-Please refer to the [Github project](https://github.com/orgs/openeew/projects) for the current roadmap.
-
-Each individual Github repo will contain additional issues that need resolving.
-
-## Contributing
-Please read [our contributing guidelines](https://openeew.com/docs/contributing) for details of how you can get involved, and [Code of Conduct](CODE_OF_CONDUCT.md) for information about how to participate.
-
-## Authors
-* **Grillo** - *Initial work* - [Grillo](https://grillo.io)
 
 Enjoy!  Give us [feedback](https://github.com/openeew/openeew/issues) if you have suggestions on how to improve this information.
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,56 @@
 [![License](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) 
 ![CCBYSA](https://img.shields.io/badge/License-CC%20BY%20SA%204-blue)
 
-
 <img src="/images/logo_2020.svg" alt="logo" width="400px"/>
+OpenEEW is an open network of affordable seismic stations distributed around the world that send data to a detection system for earthquake early-warnings (EEWs). 
+
+Traditional government-run EEWs have cost 10s millions of USD, but instead we rely on modern off-the-shelf IoT and Cloud technologies. Since 2017, Grillo has demonstrated that a cheaper IoT-based EEW can perform as well as an expensive traditional solution.
+
+## Learn More
+Please refer here for more information about the various Earthquake Early-Warnings, their evolution and the uniqueness of our open source solution.
+
+## Get Started
+To participate you need an OpenEEW seismic sensor. You can make your own PCB following these instructions, or you can buy one at directly from PCBWay.
+
+Once you have a sensor, please refer to the Wiki for instructions on installation, provisioning, and monitoring.
+
+## Dashboard
+To view sensors and earthquake events you can visit the OpenEEW dashboard. If you have your own sensor you can sign in here and see additional information relating to your device.
+
+## Contribute
+You can contribute to OpenEEW by
+
+- Providing Pull Requests (Features, Proof of Concepts, Language files or Fixes)
+- Testing new released features and reporting issues
+- Contributing missing documentation for features
+
+Our community is active on [Slack](https://join.slack.com/t/openeew/shared_invite/zt-cibhc0za-XKReMPobi2DsrPusORJZVQ) where you can ask questions and offer suggestions. Please refer to our [Code of Conduct](https://github.com/openeew/openeew/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines]().
+
+## History
+OpenEEW was initiated by [Grillo](https://grillo.io) in 2019 as a means to share its growing [sensor data](https://registry.opendata.aws/grillo-openeew/) via the AWS Open Data program. In 2020, IBM and Linux Foundation joined to support the open source project and help expand it to include hardware schematics and firmware, as well as code for the detection system, dashboard and alerts.
 
 
 
-Let's create ***earthquake early-warning (EEW) systems*** for every seismically-vulnerable community in the world!
 
-[OpenEEW](https://openeew.com) is an initiative by [Grillo](https://grillo.io), IBM and Linux Foundation to democratize EEW systems throughout the world by sharing our:
-* Entire archive of **unprocessed accelerometer data** from Mexico, Chile and other countries, including earthquakes records with magnitudes above 7 and recorded at different distances 
-* **Algorithms for the detection and characterization of earthquakes** in real time
-* **Software examples** for creating your own EEW server
-* **Hardware designs and firmware** so you can build your own IoT-based seismic sensors
-* **Application software** so that users can receive your alerts via mobile apps, devices and more
-* **Guidance to help with your project** including deployment of sensors, installations, and more
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 ## What is an Earthquake Early-Warning (EEW) ?
 An earthquake early-warning (EEW) system is a set of capacities to detect and characterize a significant earthquake, estimating the distribution of shaking and distribute the information to communities and organizations, enabling individuals to prepare and act appropriately and in sufficient time to reduce the possibility of loss and protect life. 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ OpenEEW is an open network of affordable seismic stations distributed around the
 Traditional government-run EEWs have cost 10s millions of USD, but instead OpenEEW relies on modern and affordable off-the-shelf IoT and Cloud technologies. Since 2017 [Grillo has demonstrated](https://grillo.io/comparison-of-mexicos-earthquake-early-warning-systems/) that a cheaper IoT-based EEW can perform as well as an expensive traditional solution.
 
 ## Learn More
-Please refer to the Wiki for more information about Earthquake Early-Warnings, the function, various implementations, and the uniqueness of OpenEEW's open source solution.
+Please refer to the [Wiki](https://github.com/openeew/openeew/wiki) for more information about Earthquake Early-Warnings, the function, various implementations, and the uniqueness of OpenEEW's open source solution.
 
 ## Get Started
-To participate you need an OpenEEW seismic sensor. You can make your own PCB following these instructions, or you can buy one at directly from PCBWay.
+To participate you need an OpenEEW seismic sensor. You can make your own PCB following [these instructions](https://github.com/openeew/openeew-sensor), or you can buy one at directly from [PCBWay]().
 
-Once you have a sensor, please refer to the Wiki for instructions on installation, provisioning, and monitoring.
+Once you have a sensor, please refer to the [Wiki](https://github.com/openeew/openeew/wiki) for instructions on installation, provisioning, and monitoring.
 
 ## Dashboard
-To view sensors and earthquake events you can visit the OpenEEW dashboard. If you have your own sensor you can sign in here and see additional information relating to your device.
+To view sensors and earthquake events you can visit the [OpenEEW dashboard](https://dashboard.openeew.com/). If you have your own sensor you can sign in here and see additional information relating to your device.
 
 ## Contribute
 You can contribute to OpenEEW by


### PR DESCRIPTION
The existing readme is out of date. 

It was written as a list of parts, rather than an introduction to the project and a quick start guide.

The links are in many cases out of date. 

The references to the website are removed here because it will be overhauled, and any technical instructions will move the wiki in the master repo folder.

